### PR TITLE
Add double-click to edit cell functionality

### DIFF
--- a/src/components/ExcelClone.js
+++ b/src/components/ExcelClone.js
@@ -32,6 +32,15 @@ const ExcelClone = () => {
     setFormulaBarValue(value);
   };
 
+  // Handle double-click for editing
+  const handleDoubleClick = (rowIndex, colIndex, e) => {
+    handleCellSelect(rowIndex, colIndex);
+    const cellInput = document.getElementById(`cell-${rowIndex}-${colIndex}`);
+    if (cellInput) {
+      cellInput.select();
+    }
+  };
+
   return (
     <div className="flex flex-col h-screen">
       {/* Top Bar */}
@@ -83,11 +92,13 @@ const ExcelClone = () => {
                     }`}
                   >
                     <input
+                      id={`cell-${rowIndex}-${colIndex}`} // Unique ID for each cell
                       type="text"
                       className="w-full h-full px-2 py-1 border-none outline-none bg-transparent"
                       value={data[rowIndex][colIndex]}
                       onChange={(e) => handleCellChange(rowIndex, colIndex, e.target.value)}
                       onClick={() => handleCellSelect(rowIndex, colIndex)}
+                      onDoubleClick={(e) => handleDoubleClick(rowIndex, colIndex, e)}
                     />
                   </td>
                 ))}


### PR DESCRIPTION
Implemented a double-click feature on cells that allows users to directly edit the content within a cell. Added a unique id for each <input> element based on the cell's row and column index to target specific cells for editing. The handleDoubleClick function updates the selected cell and formula bar value, and selects the content of the cell for easy editing. The onDoubleClick event handler is added to each <input> to trigger the direct editing mode.